### PR TITLE
Kw/feature branch frontend changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,3 +1,3 @@
 {
-  "datafile": "data/data-1month.json"
+  "datafile": "data/data.json"
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -119,10 +119,6 @@ ul {
   top: 50%;
   left: 100%;
 }
-/*content: "\25C0"; /* left arrow */
-/*content: "\25b6"; /* right arrow */
-/*content: "\25b2"; /* up arrow */
-/*content: "\25bc"; /* down arrow */
 
 /* OLD BASIC TOOLTIP STYLES */
 /*.tooltip {*/

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,9 +2,9 @@
   cursor: pointer;
 }
 
-/*.node--leaf {*/
-/*  fill: white;*/
-/*}*/
+.node--leaf {
+  fill: white;
+}
 
 .label {
   font: 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -12,17 +12,11 @@
   text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
 }
 
-/*.label,*/
-/*.node--root,*/
-/*.node--leaf {*/
-/*}*/
-
 .node--root {
   display: none;
 }
 
 /* VIS SIZING AND RESPONSIVENESS STYLES */
-
 .vis-svg {
   background: rgb(217, 224, 227);
 }
@@ -53,6 +47,7 @@
   -webkit-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -moz-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   max-width: 350px; /* max tooltip width. If this is changed, must change MAX_TOOLTIP_WIDTH constant in circlepack.js */
+  min-width: unset;
 }
 
 .tooltip-dataverse {

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,11 +2,6 @@
   cursor: pointer;
 }
 
-.node:hover {
-  stroke: #000;
-  stroke-width: 1.5px;
-}
-
 .node--leaf {
   fill: white;
 }
@@ -31,6 +26,11 @@
 }
 
 /*    TOOLTIP STYLES    */
+.tooltip a {
+  color: unset;
+  text-decoration: unset;
+}
+
 .tooltip-title {
   display: block;
   margin-bottom: 5px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,9 +2,9 @@
   cursor: pointer;
 }
 
-.node--leaf {
-  fill: white;
-}
+/*.node--leaf {*/
+/*  fill: white;*/
+/*}*/
 
 .label {
   font: 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -12,10 +12,10 @@
   text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
 }
 
-.label,
-.node--root,
-.node--leaf {
-}
+/*.label,*/
+/*.node--root,*/
+/*.node--leaf {*/
+/*}*/
 
 .node--root {
   display: none;
@@ -36,7 +36,7 @@
 .tooltip-title {
   display: block;
   margin-bottom: 5px;
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 600;
 }
 
@@ -52,7 +52,7 @@
   box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -webkit-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -moz-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
-  max-width: 600px;
+  max-width: 350px; /* max tooltip width. If this is changed, must change MAX_TOOLTIP_WIDTH constant in circlepack.js */
 }
 
 .tooltip-dataverse {
@@ -62,14 +62,14 @@
   color: rgb(73, 134, 190);
 }
 .tooltip-date {
-  font-size: 24px;
+  font-size: 18px;
   color: rgb(130,130,130)
   /*font-weight: 400;*/
 }
 .tooltip-desc {
   display: list-item;
   margin-bottom: 5px;
-  font-size: 24px;
+  font-size: 18px;
   /*font-weight: 400;*/
 }
 ul {

--- a/css/styles.css
+++ b/css/styles.css
@@ -46,7 +46,7 @@
   box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -webkit-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -moz-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
-  max-width: 350px; /* max tooltip width. If this is changed, must change MAX_TOOLTIP_WIDTH constant in circlepack.js */
+  max-width: 350px; /* max tooltip width */
   min-width: unset;
 }
 
@@ -81,7 +81,7 @@ ul {
   line-height: 1;
   color: white;
   position: absolute;
-  /* pointer-events: none is needed so that hovering over triangle extender of
+  /* 'pointer-events: none' is needed so that hovering over triangle extender of
   a westward tooltip does not interfere with circle hover */
   pointer-events: none;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -21,6 +21,8 @@
   display: none;
 }
 
+/* VIS SIZING AND RESPONSIVENESS STYLES */
+
 .vis-svg {
   background: rgb(217, 224, 227);
 }
@@ -84,6 +86,18 @@ ul {
   line-height: 1;
   color: white;
   position: absolute;
+  /* pointer-events: none is needed so that hovering over triangle extender of
+  a westward tooltip does not interfere with circle hover */
+  pointer-events: none;
+}
+
+/* Northward tooltips */
+.tooltip.n:after {
+  content: "\25BC";
+  margin: -4px 0 0 0;
+  top: 100%;
+  left: 50%;
+  /*text-align: center;*/
 }
 
 /* Adds the left arrow on the tooltip */
@@ -94,11 +108,28 @@ ul {
   left: -8px;
 }
 
+/* Southward tooltips */
+.tooltip.s:after {
+  content: "\25B2";
+  margin: 0 0 4px 0;
+  top: -8px;
+  left: 50%;
+
+}
+
+/* Westward tooltips */
+.tooltip.w:after {
+  content: "\25B6";
+  margin: -4px 0 0 -4px;
+  top: 50%;
+  left: 100%;
+}
 /*content: "\25C0"; /* left arrow */
 /*content: "\25b6"; /* right arrow */
 /*content: "\25b2"; /* up arrow */
 /*content: "\25bc"; /* down arrow */
 
+/* OLD BASIC TOOLTIP STYLES */
 /*.tooltip {*/
 /*  position: absolute;*/
 /*  z-index: 10;*/

--- a/css/styles.css
+++ b/css/styles.css
@@ -20,24 +20,93 @@
 .label,
 .node--root,
 .node--leaf {
-  pointer-events: none;
 }
 
 .node--root {
   display: none;
 }
 
-.tooltip-details {
-  position: absolute;
-  z-index: 10;
-  opacity: 0;
-  background-color: white;
-  border: solid;
-  border-width: 2px;
-  border-radius: 5px;
-  padding: 5px;
-}
-
 .vis-svg {
   background: rgb(217, 224, 227);
 }
+
+/*    TOOLTIP STYLES    */
+.tooltip-title {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.tooltip {
+  line-height: 1.5;
+  padding: 12px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  opacity: 0.5;
+  background-color: white;
+  border-width: 2px;
+  border-radius: 5px;
+  padding: 20px;
+  box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
+  -webkit-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
+  -moz-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
+  max-width: 600px;
+}
+
+.tooltip-dataverse {
+  color: rgb(194, 107, 53);
+}
+.tooltip-dataset {
+  color: rgb(73, 134, 190);
+}
+.tooltip-date {
+  font-size: 24px;
+  color: rgb(130,130,130)
+  /*font-weight: 400;*/
+}
+.tooltip-desc {
+  display: list-item;
+  margin-bottom: 5px;
+  font-size: 24px;
+  /*font-weight: 400;*/
+}
+ul {
+  padding-inline-start: 30px
+}
+
+/* Creates a small triangle extender for the tooltip */
+/* Reference: https://github.com/caged/d3-tip/blob/master/examples/example-styles.css */
+.tooltip:after {
+  box-sizing: border-box;
+  display: inline;
+  font-size: 10px;
+  width: 100%;
+  line-height: 1;
+  color: white;
+  position: absolute;
+}
+
+/* Adds the left arrow on the tooltip */
+.tooltip.e:after {
+  content: "\25C0";
+  margin: -4px 0 0 0;
+  top: 50%;
+  left: -8px;
+}
+
+/*content: "\25C0"; /* left arrow */
+/*content: "\25b6"; /* right arrow */
+/*content: "\25b2"; /* up arrow */
+/*content: "\25bc"; /* down arrow */
+
+/*.tooltip {*/
+/*  position: absolute;*/
+/*  z-index: 10;*/
+/*  opacity: 0;*/
+/*  background-color: white;*/
+/*  border: solid;*/
+/*  border-width: 2px;*/
+/*  border-radius: 5px;*/
+/*  padding: 5px;*/
+/*}*/
+

--- a/data/data-1month.json
+++ b/data/data-1month.json
@@ -467,36 +467,44 @@
       "name": "MEDSL Dataverse",
       "date": "2018-09-10 11:22:44.492",
       "diff": 252,
+      "link": "https://dataverse.harvard.edu/dataverse/medsl",
       "children": [
         {
           "children": [
             {
               "children": [
                 {
-                  "name": "State Office-Level Returns 2016"
+                  "name": "State Office-Level Returns 2016",
+                  "link": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/XSOFHD"
                 }
               ],
-              "name": "State Elections"
+              "name": "State Elections",
+              "link": "https://dataverse.harvard.edu/dataverse/medsl_state"
             }
           ],
-          "name": "MEDSL Election Returns Dataverse"
+          "name": "MEDSL Election Returns Dataverse",
+          "link": "https://dataverse.harvard.edu/dataverse/medsl_election_returns"
         },
         {
           "children": [
             {
               "children": [],
-              "name": "EPI Full Reproduction Files"
+              "name": "EPI Full Reproduction Files",
+              "link": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/4AEEQV"
             },
             {
               "children": [],
-              "name": "Elections Performance Index Indicators 2008\u20132016"
+              "name": "Elections Performance Index Indicators 2008\u20132016",
+              "link": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/SKCC60"
             },
             {
               "children": [],
-              "name": "Elections Performance Index 2016"
+              "name": "Elections Performance Index 2016",
+              "link": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/MQMMHZ"
             }
           ],
-          "name": "Elections Performance Index Dataverse"
+          "name": "Elections Performance Index Dataverse",
+          "link": "https://dataverse.harvard.edu/dataverse/epi"
         }
       ]
     },
@@ -735,6 +743,7 @@
       "name": "BMPER_EMT DATAVERSE",
       "date": "2018-11-12 08:45:41.549",
       "diff": 315,
+      "link": "https://dataverse.harvard.edu/dataverse/BMPER_EMT",
       "children": [
         {
           "children": [],

--- a/index.html
+++ b/index.html
@@ -6,10 +6,6 @@
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
-    <ul>
-      <li class="random">hi</li>
-      <li class="random">hello</li>
-    </ul>
     <div id="circlepack"></div>
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="js/d3-tip.js"></script>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
+    <ul>
+      <li class="random">hi</li>
+      <li class="random">hello</li>
+    </ul>
     <div id="circlepack"></div>
     <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="js/d3-tip.js"></script>
     <script src="js/circlepack.js"></script>
     <script src="js/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,28 @@
   <head>
     <title>dataverse-homepage-viz</title>
     <meta charset="utf-8" />
+    <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
     <div id="circlepack"></div>
+    <div id="slider"></div>
+<!--    <div class="container">-->
+<!--      <div class="row">-->
+<!--        <div class="col">-->
+<!--            <p></p>-->
+<!--            <div id="circlepack"></div>-->
+<!--            <div id="slider"></div>-->
+<!--        </div>-->
+<!--      </div>-->
+<!--    </div>-->
     <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="https://unpkg.com/d3-simple-slider"></script>
+<!--    <script src="js/jquery.min.js"></script>-->
+<!--    <script src="js/popper.min.js"></script>-->
+<!--    <script src="js/bootstrap.min.js"></script>-->
     <script src="js/d3-tip.js"></script>
+    <script src="js/visSlider.js"></script>
     <script src="js/circlepack.js"></script>
     <script src="js/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -3,26 +3,23 @@
   <head>
     <title>dataverse-homepage-viz</title>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="css/bootstrap.min.css">
+<!--    <link rel="stylesheet" href="css/bootstrap.min.css">-->
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
     <div id="circlepack"></div>
     <div id="slider"></div>
-<!--    <div class="container">-->
-<!--      <div class="row">-->
-<!--        <div class="col">-->
-<!--            <p></p>-->
-<!--            <div id="circlepack"></div>-->
-<!--            <div id="slider"></div>-->
+<!--        <div class="container">-->
+<!--          <div class="row">-->
+<!--            <div class="col">-->
+<!--                <p></p>-->
+<!--                <div id="circlepack"></div>-->
+<!--                <div id="slider"></div>-->
+<!--            </div>-->
+<!--          </div>-->
 <!--        </div>-->
-<!--      </div>-->
-<!--    </div>-->
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="https://unpkg.com/d3-simple-slider"></script>
-<!--    <script src="js/jquery.min.js"></script>-->
-<!--    <script src="js/popper.min.js"></script>-->
-<!--    <script src="js/bootstrap.min.js"></script>-->
     <script src="js/d3-tip.js"></script>
     <script src="js/visSlider.js"></script>
     <script src="js/circlepack.js"></script>

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -7,7 +7,7 @@ Circlepack = function(_parentElement, _data){
 	this.parentElement = _parentElement;
 	this.data = _data;
 	this.initVis();
-	this.nodeSelected = false;
+	this.nodeSelected; // the current node that is selected
 }
 
 function getRandomInt(min, max) {
@@ -24,7 +24,7 @@ function getRandomInt(min, max) {
    var vis = this;
    console.log("initVis");
    vis.margin = { top: 0, right: 0, bottom: 0, left: 0 };
-   vis.width =2100 - vis.margin.left - vis.margin.right;
+   vis.width = 2100 - vis.margin.left - vis.margin.right;
    vis.height = 600 - vis.margin.left - vis.margin.right;
    vis.diameter = vis.width;
 
@@ -34,7 +34,7 @@ function getRandomInt(min, max) {
 	    .attr("height", vis.height + vis.margin.top + vis.margin.bottom)
         .append("g")
         // .attr("transform", "translate(" + vis.width / 2 + "," + vis.height / 2 + ")");
-	       .attr("transform", "translate(" + vis.margin.left + "," + vis.margin.top + ")");
+	       .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
 
    // Scales and axes
 
@@ -95,8 +95,9 @@ Circlepack.prototype.wrangleData = function(){
       return 10;
     })
     .sort(function(a, b) {
-        b_diff = b.data.diff //|| 400 //TODO: handle zero value case?
-        a_diff = a.data.diff //|| 400 //TODO: if *.data.diff is undefined push it to the edge? if it's 0 push it to center
+        //TODO: handle *.data.diff is undefined
+        b_diff = b.data.diff
+        a_diff = a.data.diff
         return a_diff - b_diff;
         //"The specified function is passed two nodes a and b to compare.
         // If a should be before b, the function must return a value less than zero;
@@ -128,14 +129,13 @@ Circlepack.prototype.updateVis = function(){
     .append("circle")
     .attr("r", d => d.r)
     .attr("transform", function(d){
-        return "translate(" + d.x + "," + d.y + ")";
+        return `translate(${d.x}, ${d.y})`;
       // let x = getRandomInt(0,vis.width);
       // let y = getRandomInt(0, vis.height);
       // return "translate(" + x + "," + y + ")";
     })
     .attr("class", function(d) {
       // "?" is the ternary operator
-      // TODO: revise this
       return d.parent
         ? d.children
           ? "node"
@@ -146,22 +146,48 @@ Circlepack.prototype.updateVis = function(){
       return d.children ? vis.color(d.depth) : null;
     })
     .on("mouseover", function(d) {
+      // only show tooltip if nothing is selected
       if (!vis.nodeSelected) vis.tip.hide(d).show(d)
+      // always show outline
+      d3.select(this)
+        .attr("stroke-width", "1.5px")
+        .attr("stroke", "#000")
     })
     .on("mouseout", function(d) {
-      if (!vis.nodeSelected) vis.tip.hide(d)
+      if (vis.nodeSelected !== this) {
+        // set stroke to none on mouseout if not mousing over a selected node and nothing is selected
+        d3.select(this)
+          .attr("stroke", "none")
+        // only hide tooltip if no node is selected
+        if (!vis.nodeSelected) vis.tip.hide(d);
+      }
     })
     .on("click", function(d) {
-      if (vis.nodeSelected) {
-        //unclick node
-        vis.nodeSelected = false
-        vis.tip.hide(d)
-      } else {
-        //click node
-        vis.nodeSelected = true
-        vis.tip.hide(d).show(d)
+      if (!vis.nodeSelected) {
+        // if clicking a node and nothing is selected, select it and show tooltip
+        vis.nodeSelected = this;
+        vis.tip.hide(d).show(d);
         d3.select(this)
-          .style("stroke-width", '1.5px')
+          .attr("stroke-width", '1.5px')
+          .attr("stroke", "#000")
+
+      } else if (vis.nodeSelected === this) {
+        // if clicking a node that is already selected, unselect it and hide tooltip
+        vis.nodeSelected = undefined;
+        vis.tip.hide(d);
+        d3.select(this)
+          .attr("stroke", 'none')
+
+      } else if (vis.nodeSelected && vis.nodeSelected !== this) {
+        // if clicking a node and a different node is already selected, unselect it and select this one
+        var previous = vis.nodeSelected
+        vis.nodeSelected = this;
+        vis.tip.hide(d).show(d);
+        d3.select(previous)
+          .attr("stroke", 'none')
+        d3.select(this)
+          .attr("stroke-width", '1.5px')
+          .attr("stroke", "#000")
       }
     })
 
@@ -224,41 +250,42 @@ function isRootNode(node) {
 Circlepack.prototype.formatTooltip = function(d) {
   var title_html = ''
   var children_html = ''
-  //temporary for debugging:
+  var style_tag = ''
+
+  /*temporary for debugging:*/
   var diff = `<div class="tooltip-diff">${d.data.diff}</div>`
 
   // if date is present parse string as a Date and format it
   var date_label = d.data.date ? formatDate(parseDateTime(d.data.date)) : 'Date unknown'
   var date_html = `<div class="tooltip-date">${date_label}</div>`
+  var title_link = d.data.link
 
   // if current node you're hovering over is a dataset, construct dataset title only
-  // else if it's a dataverse, construct a dataverse title and add children to the description section
   if (isDataset(d)) {
-    title_html = `<div class="tooltip-dataset tooltip-title">${d.data.name}</div>`
+    title_html = `<div class="tooltip-dataset tooltip-title"><a href="${title_link}" target="_blank">${d.data.name}</a></div>`
 
+  // else if it's a dataverse, construct a dataverse title and add children to the description section
   } else if (isDataverse(d)) {
-    title_html = `<div class="tooltip-dataverse tooltip-title">${d.data.name}</div>`
-    var style_tag = ''
+    title_html = `<div class="tooltip-dataverse tooltip-title"><a href="${title_link}" target="_blank">${d.data.name}</a></div>`
     children_html = children_html.concat(`<ul>`)
 
-    // console.log(d.children)
+    // if dataverse has more than 5 children show link to all datasets
     if (d.children.length > 5) {
-      children_html = children_html.concat(`<li class="${style_tag} tooltip-desc"><a href="https://www.google.com" target="_blank">All datasets</a></li>`)
+      style_tag = "tooltip-dataset"
+      children_html = children_html.concat(`<li class="${style_tag} tooltip-desc"><a href="${title_link}" target="_blank">All datasets</a></li>`)
+
     } else {
+      // else show all children
       d.children.forEach(child => {
         if (isDataset(child)) {
           style_tag = "tooltip-dataset"
         } else if (isDataverse(child)) {
           style_tag = "tooltip-dataverse"
         }
-        children_html = children_html.concat(`<li class="${style_tag} tooltip-desc">${child.data.name}</li>`)
+        children_html = children_html.concat(`<li class="${style_tag} tooltip-desc"><a href="${child.data.link}" target="_blank">${child.data.name}</a></li>`)
       })
     }
     children_html = children_html.concat(`</ul>`)
-
-  } else {
-    // Found root node. Do nothing
-    // console.log('new found node node--root')
   }
   return '<div class="tooltip-details">' + title_html + date_html + children_html + diff + '</div">'
 }

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -210,8 +210,8 @@ var formatDate = d3.timeFormat("%b %e, %Y");
 
 // Set the transition duration
 // Usage: d3.select("circle").transition(t)
-var t = d3.transition()
-  .duration(500)
+// var t = d3.transition()
+//   .duration(500)
 
 /*
  * @param node -- circlepack hierarchy node
@@ -262,7 +262,7 @@ Circlepack.prototype.resetTooltip = function() {
 
 /*
  * @param d -- circlepack hierarchy node
- * @param circleSelect -- d3 circle selection
+ * @param circle -- d3 circle selection
  * Hide tooltips on mouseout
  */
 Circlepack.prototype.hideTooltipOnMouseout = function(d, circle) {
@@ -277,20 +277,16 @@ Circlepack.prototype.hideTooltipOnMouseout = function(d, circle) {
 
 /*
  * @param d -- circlepack hierarchy node
- * @param circleSelect -- d3 circle selection
+ * @param circle -- d3 circle selection
  * Shows tooltip for a circle. Set the direction to east or to the west
  */
 Circlepack.prototype.showTooltipOnMouseover = function(d, circle) {
   let vis = this;
   let circle_x = d.x;
-  // let circleSelect = d3.select(circle)
-  // let el = document.getElementById(vis.parentElement)
-  // let circlepack_width = el.offsetWidth;
 
   // only show tooltip on hover if none are selected
   if (!vis.nodeSelected) {
     // if scaled circle_x position is in the right third of the screen, draw a westward tooltip
-    // console.log(`${circle_x} / ${vis.width} = ${circle_x / circlepack_width}`)
     if (circle_x / vis.width >= 0.67) {
       vis.tip.hide(d)
         .direction('w').offset([-5,-12])
@@ -307,7 +303,7 @@ Circlepack.prototype.showTooltipOnMouseover = function(d, circle) {
 
 /*
  * @param d -- circlepack hierarchy node
- * @param circleSelect -- d3 circle selection
+ * @param circle -- d3 circle selection
  * Shows tooltip when a circle is clicked
  */
 Circlepack.prototype.showTooltipOnSelect = function(d, circle) {
@@ -388,6 +384,7 @@ Circlepack.prototype.formatTooltip = function(d) {
     }
     children_html = children_html.concat(`</ul>`)
   }
-  return '<div class="tooltip-details">' + title_html + date_html + children_html + diff + '</div">'
+  // return '<div class="tooltip-details">' + title_html + date_html + children_html + diff + '</div">'
+  return '<div class="tooltip-details">' + title_html + date_html + children_html + '</div">'
 }
 

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -250,7 +250,6 @@ function isRootNode(node) {
 //////////////////////////////////////////
 
 /*
- * @param d -- circlepack hierarchy node
  * Hides tooltip and removes circle highlight
  */
 Circlepack.prototype.resetTooltip = function() {

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -6,8 +6,10 @@
 Circlepack = function(_parentElement, _data){
 	this.parentElement = _parentElement;
 	this.data = _data;
-	this.initVis();
 	this.nodeSelected; // the current node that is selected
+  // this.direction = 'e';
+
+  this.initVis();
 }
 
 function getRandomInt(min, max) {
@@ -24,18 +26,21 @@ function getRandomInt(min, max) {
    var vis = this;
    console.log("initVis");
    vis.margin = { top: 0, right: 0, bottom: 0, left: 0 };
-   vis.width = 2100 - vis.margin.left - vis.margin.right;
-   vis.height = 600 - vis.margin.left - vis.margin.right;
+
+   var totalWidth = document.getElementById(vis.parentElement).offsetWidth
+   vis.width = totalWidth - vis.margin.left - vis.margin.right;
+   vis.height = 450 - vis.margin.left - vis.margin.right;
    vis.diameter = vis.width;
 
    vis.svg = d3.select("#" + vis.parentElement).append("svg")
       .attr("class", "vis-svg")
       .attr("id", "vis-svg-id")
-	    .attr("width", vis.width + vis.margin.left + vis.margin.right)
-	    .attr("height", vis.height + vis.margin.top + vis.margin.bottom)
-        .append("g")
-        // .attr("transform", "translate(" + vis.width / 2 + "," + vis.height / 2 + ")");
-	       .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
+      // .attr("preserveAspectRatio", "xMinYMin meet")
+      .attr("viewBox", `0 0 ${vis.width} ${vis.height}`)
+      .attr("width", "100%")
+      .attr("height", "100%")
+      .append("g")
+	    .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
 
    // Scales and axes
 
@@ -52,8 +57,7 @@ function getRandomInt(min, max) {
    // References: https://github.com/caged/d3-tip/blob/master/examples/arrow-styles.html
   vis.tip = d3.tip()
     .attr("class", "tooltip")
-    .offset([0,10])
-    .direction('e')
+    .offset([-5,12]).direction('e')
     .html(function(d) {
       return vis.formatTooltip(d)
     });
@@ -96,22 +100,21 @@ Circlepack.prototype.wrangleData = function(){
       return 10;
     })
     .sort(function(a, b) {
-        //TODO: handle *.data.diff is undefined
-        b_diff = b.data.diff
-        a_diff = a.data.diff
-        return a_diff - b_diff;
-        //"The specified function is passed two nodes a and b to compare.
-        // If a should be before b, the function must return a value less than zero;
-        // if b should be before a, the function must return a value greater than zero;"
-        // -- https://github.com/d3/d3-hierarchy#node_sort
+      b_diff = b.data.diff === undefined ? 0 : b.data.diff
+      a_diff = a.data.diff === undefined ? 0 : a.data.diff
+      return a_diff - b_diff;
+      //"The specified function is passed two nodes a and b to compare.
+      // If a should be before b, the function must return a value less than zero;
+      // if b should be before a, the function must return a value greater than zero;"
+      // -- https://github.com/d3/d3-hierarchy#node_sort
     });
 
     // Config pack function
-    vis.pack = d3
-      .pack()
+    vis.pack = d3.pack()
       .size([vis.width, vis.height])
       // For nested circles, the distance between the circle itself and circles inside it.
       .padding(4);
+    // Invoke pack function
     vis.nodes = vis.pack(vis.root).descendants();
 
   vis.updateVis();

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -23,8 +23,8 @@ function getRandomInt(min, max) {
    var vis = this;
    console.log("initVis");
    vis.margin = { top: 0, right: 0, bottom: 0, left: 0 };
-   vis.width = 1050 - vis.margin.left - vis.margin.right;
-   vis.height = 300 - vis.margin.left - vis.margin.right;
+   vis.width =2100 - vis.margin.left - vis.margin.right;
+   vis.height = 600 - vis.margin.left - vis.margin.right;
    vis.diameter = vis.width;
 
    vis.svg = d3.select("#" + vis.parentElement).append("svg")
@@ -46,10 +46,16 @@ function getRandomInt(min, max) {
 
   // Legend
 
-  // Tooltip
-  vis.tooltip = d3.select("#" + vis.parentElement).append("div")
-    .attr("class", "tooltip-details")
-    .text("a simple tooltip");
+   // Tooltip
+   // References: https://github.com/caged/d3-tip/blob/master/examples/arrow-styles.html
+  vis.tip = d3.tip()
+    .attr("class", "tooltip")
+    .offset([0,10])
+    .direction('e')
+    .html(function(d) {
+      return vis.formatTooltip(d)
+    });
+    vis.svg.call(vis.tip);
 
    vis.wrangleData();
  }
@@ -81,27 +87,20 @@ Circlepack.prototype.wrangleData = function(){
   // }
   // levels(vis.data, 0);
 
-  // Reorganize data
   vis.root = d3
     .hierarchy(vis.data)
-    //.sum(function(d) { return d.size; })
-    //
     .sum(function(d) {
-      //console.log("d: " + d.name);
       //return d.size;
       return 10;
     })
     .sort(function(a, b) {
-      //console.log("b: " + b.value + " a:" + a.value);
-      // changes the orientation
-      //return b.value - a.value;
-      //"The specified function is passed two nodes a and b to compare.
-      // If a should be before b, the function must return a value less than zero;
-      // if b should be before a, the function must return a value greater than zero;"
-      // -- https://github.com/d3/d3-hierarchy#node_sort
-      random = getRandomInt(-1, 1);
-      //console.log(random);
-      return random;
+        b_diff = b.data.diff //|| 400 //TODO: handle zero value case?
+        a_diff = a.data.diff //|| 400 //TODO: if *.data.diff is undefined push it to the edge? if it's 0 push it to center
+        return a_diff - b_diff;
+        //"The specified function is passed two nodes a and b to compare.
+        // If a should be before b, the function must return a value less than zero;
+        // if b should be before a, the function must return a value greater than zero;"
+        // -- https://github.com/d3/d3-hierarchy#node_sort
     });
 
     // Config pack function
@@ -119,13 +118,11 @@ Circlepack.prototype.wrangleData = function(){
  *  The drawing function
  */
 Circlepack.prototype.updateVis = function(){
-  console.log("updateVis");
   var vis = this;
-  console.log(vis);
 
   vis.circles = vis.svg.selectAll("circle")
     .data(vis.nodes);
-  console.log(vis.circles);
+
   vis.circles.enter()
     .append("circle")
     .attr("r", d => d.r)
@@ -137,6 +134,7 @@ Circlepack.prototype.updateVis = function(){
     })
     .attr("class", function(d) {
       // "?" is the ternary operator
+      // TODO: revise this
       return d.parent
         ? d.children
           ? "node"
@@ -147,25 +145,102 @@ Circlepack.prototype.updateVis = function(){
       return d.children ? vis.color(d.depth) : null;
     })
     .on("mouseover", function(d) {
-      vis.tooltip.html(`<div id="tooltip-text">${d.data.name}</div>`);
-      vis.tooltip.transition()
-        .duration(300)
-        .style("opacity", 1)
-        // .style("top", `${d.x - d.r - vis.height}px`)
-        // .style("left", `${d.y - d.r}px`)
-    })
-    .on("mousemove", function(d) {
-      vis.tooltip
-        .style("top", d3.event.pageY - 10 + "px")
-        .style("left", d3.event.pageX + 10 + "px");
+      vis.tip.show(d)
     })
     .on("mouseout", function(d) {
-      vis.tooltip.transition()
-        .duration(500)
-        .style("opacity", 0);
+      vis.tip.hide(d)
     });
 
     // Remove old data
     // Update axes
 
 }
+
+
+//////////////////////////////////////////
+/*            HELPER METHODS            */
+//////////////////////////////////////////
+
+// Parse a string with the format "2018-11-12 08:45:41.549" into a Javascript Date object
+var parseDateTime = d3.timeParse("%Y-%m-%d %H:%M:%S.%L");
+
+// Format date objects like: Jan 30, 2020
+var formatDate = d3.timeFormat("%b %e, %Y");
+
+// Set the transition duration
+// Usage: d3.select("circle").transition(t)
+var t = d3.transition()
+  .duration(500)
+
+/*
+ * @param node -- circlepack hierarchy node
+ * @return boolean -- true if node is a dataset
+ */
+function isDataset(node) {
+  // if node does not have a parent, it must be the root node
+  if(!node.parent) return false
+  // if node has no children, it is a dataset
+  return !node.children
+}
+
+/*
+ * @param node -- circlepack hierarchy node
+ * @return boolean -- true if node is a dataverse
+ */
+function isDataverse(node) {
+  // if node does not have a parent, it must be the root node
+  if(!node.parent) return false
+  // if node has children, it is a dataverse
+  return node.children
+}
+
+/*
+ * @param node -- circlepack hierarchy node
+ * @return boolean -- true if node is the root node
+ */
+function isRootNode(node) {
+  // if node does not have a parent, it must be the root node
+  return !node.parent
+}
+
+/*
+ * @param node -- circlepack hierarchy node
+ * @return boolean -- true if node is the root node
+ */
+Circlepack.prototype.formatTooltip = function(node) {
+  var title_html = ''
+  var children_html = ''
+  //temporary for debugging:
+  var diff = `<div class="tooltip-diff">${d.data.diff}</div>`
+
+  // if date is present parse string as a Date and format it
+  var date_label = d.data.date ? formatDate(parseDateTime(d.data.date)) : 'Date unknown'
+  var date_html = `<div class="tooltip-date">${date_label}</div>`
+
+  // if current node you're hovering over is a dataset, construct dataset title only
+  // else if it's a dataverse, construct a dataverse title and add children to the description section
+  if (isDataset(d)) {
+    title_html = `<div class="tooltip-dataset tooltip-title">${d.data.name}</div>`
+
+  } else if (isDataverse(d)) {
+    title_html = `<div class="tooltip-dataverse tooltip-title">${d.data.name}</div>`
+    var style_tag = ''
+    var child_name = d.data.children[0].name
+    children_html = children_html.concat(`<ul>`)
+
+    d.children.forEach(child => {
+      if (isDataset(child)) {
+        style_tag = "tooltip-dataset"
+      } else if (isDataverse(child)) {
+        style_tag = "tooltip-dataverse"
+      }
+      children_html = children_html.concat(`<li class="${style_tag} tooltip-desc">${child.data.name}</li>`)
+    })
+    children_html = children_html.concat(`</ul>`)
+  } else {
+    // Found root node. Do nothing
+    // console.log('new found node node--root')
+  }
+  return '<div class="tooltip-details">' + title_html + date_html + children_html + diff + '</div">'
+}
+

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -94,8 +94,9 @@ Circlepack.prototype.wrangleData = function(){
       return 10;
     })
     .sort(function(a, b) {
-        b_diff = b.data.diff //|| 400 //TODO: handle zero value case?
-        a_diff = a.data.diff //|| 400 //TODO: if *.data.diff is undefined push it to the edge? if it's 0 push it to center
+        //TODO: handle *.data.diff is undefined
+        b_diff = b.data.diff
+        a_diff = a.data.diff
         return a_diff - b_diff;
         //"The specified function is passed two nodes a and b to compare.
         // If a should be before b, the function must return a value less than zero;
@@ -134,7 +135,6 @@ Circlepack.prototype.updateVis = function(){
     })
     .attr("class", function(d) {
       // "?" is the ternary operator
-      // TODO: revise this
       return d.parent
         ? d.children
           ? "node"
@@ -204,10 +204,10 @@ function isRootNode(node) {
 }
 
 /*
- * @param node -- circlepack hierarchy node
- * @return boolean -- true if node is the root node
+ * @param d -- circlepack hierarchy node
+ * @return String -- returns a String containing text to be displayed in the tooltip
  */
-Circlepack.prototype.formatTooltip = function(node) {
+Circlepack.prototype.formatTooltip = function(d) {
   var title_html = ''
   var children_html = ''
   //temporary for debugging:

--- a/js/d3-tip.js
+++ b/js/d3-tip.js
@@ -1,0 +1,320 @@
+// d3.tip
+// Copyright (c) 2013 Justin Palmer
+// ES6 / D3 v4 Adaption Copyright (c) 2016 Constantin Gavrilete
+// Removal of ES6 for D3 v4 Adaption Copyright (c) 2016 David Gotz
+//
+// Tooltips for d3.js SVG visualizations
+
+d3.functor = function functor(v) {
+  return typeof v === "function" ? v : function() {
+    return v;
+  };
+};
+
+d3.tip = function() {
+
+  var direction = d3_tip_direction,
+      offset    = d3_tip_offset,
+      html      = d3_tip_html,
+      node      = initNode(),
+      svg       = null,
+      point     = null,
+      target    = null
+
+  function tip(vis) {
+    svg = getSVGNode(vis)
+    point = svg.createSVGPoint()
+    document.body.appendChild(node)
+  }
+
+  // Public - show the tooltip on the screen
+  //
+  // Returns a tip
+  tip.show = function() {
+    var args = Array.prototype.slice.call(arguments)
+    if(args[args.length - 1] instanceof SVGElement) target = args.pop()
+
+    var content = html.apply(this, args),
+        poffset = offset.apply(this, args),
+        dir     = direction.apply(this, args),
+        nodel   = getNodeEl(),
+        i       = directions.length,
+        coords,
+        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
+        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+
+    nodel.html(content)
+      .style('position', 'absolute')
+      .style('opacity', 1)
+      .style('pointer-events', 'all')
+
+    while(i--) nodel.classed(directions[i], false)
+    coords = direction_callbacks[dir].apply(this)
+    nodel.classed(dir, true)
+      .style('top', (coords.top +  poffset[0]) + scrollTop + 'px')
+      .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+
+    return tip
+  }
+
+  // Public - hide the tooltip
+  //
+  // Returns a tip
+  tip.hide = function() {
+    var nodel = getNodeEl()
+    nodel
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+    return tip
+  }
+
+  // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
+  //
+  // n - name of the attribute
+  // v - value of the attribute
+  //
+  // Returns tip or attribute value
+  tip.attr = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().attr(n)
+    } else {
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.attr.apply(getNodeEl(), args)
+    }
+
+    return tip
+  }
+
+  // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
+  //
+  // n - name of the property
+  // v - value of the property
+  //
+  // Returns tip or style property value
+  tip.style = function(n, v) {
+    // debugger;
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().style(n)
+    } else {
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length === 1) {
+        var styles = args[0];
+        Object.keys(styles).forEach(function(key) {
+          return d3.selection.prototype.style.apply(getNodeEl(), [key, styles[key]]);
+        });
+      }
+    }
+
+    return tip
+  }
+
+  // Public: Set or get the direction of the tooltip
+  //
+  // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
+  //     sw(southwest), ne(northeast) or se(southeast)
+  //
+  // Returns tip or direction
+  tip.direction = function(v) {
+    if (!arguments.length) return direction
+    direction = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: Sets or gets the offset of the tip
+  //
+  // v - Array of [x, y] offset
+  //
+  // Returns offset or
+  tip.offset = function(v) {
+    if (!arguments.length) return offset
+    offset = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: sets or gets the html value of the tooltip
+  //
+  // v - String value of the tip
+  //
+  // Returns html value or tip
+  tip.html = function(v) {
+    if (!arguments.length) return html
+    html = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: destroys the tooltip and removes it from the DOM
+  //
+  // Returns a tip
+  tip.destroy = function() {
+    if(node) {
+      getNodeEl().remove();
+      node = null;
+    }
+    return tip;
+  }
+
+  function d3_tip_direction() { return 'n' }
+  function d3_tip_offset() { return [0, 0] }
+  function d3_tip_html() { return ' ' }
+
+  var direction_callbacks = {
+    n:  direction_n,
+    s:  direction_s,
+    e:  direction_e,
+    w:  direction_w,
+    nw: direction_nw,
+    ne: direction_ne,
+    sw: direction_sw,
+    se: direction_se
+  };
+
+  var directions = Object.keys(direction_callbacks);
+
+  function direction_n() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.n.y - node.offsetHeight,
+      left: bbox.n.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_s() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.s.y,
+      left: bbox.s.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_e() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.e.y - node.offsetHeight / 2,
+      left: bbox.e.x
+    }
+  }
+
+  function direction_w() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.w.y - node.offsetHeight / 2,
+      left: bbox.w.x - node.offsetWidth
+    }
+  }
+
+  function direction_nw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.nw.y - node.offsetHeight,
+      left: bbox.nw.x - node.offsetWidth
+    }
+  }
+
+  function direction_ne() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.ne.y - node.offsetHeight,
+      left: bbox.ne.x
+    }
+  }
+
+  function direction_sw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.sw.y,
+      left: bbox.sw.x - node.offsetWidth
+    }
+  }
+
+  function direction_se() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.se.y,
+      left: bbox.e.x
+    }
+  }
+
+  function initNode() {
+    var node = d3.select(document.createElement('div'))
+    node
+      .style('position', 'absolute')
+      .style('top', '0')
+      .style('opacity', '0')
+      .style('pointer-events', 'none')
+      .style('box-sizing', 'border-box')
+
+    return node.node()
+  }
+
+  function getSVGNode(el) {
+    el = el.node()
+    if(el.tagName.toLowerCase() === 'svg')
+      return el
+
+    return el.ownerSVGElement
+  }
+
+  function getNodeEl() {
+    if(node === null) {
+      node = initNode();
+      // re-add node to DOM
+      document.body.appendChild(node);
+    };
+    return d3.select(node);
+  }
+
+  // Private - gets the screen coordinates of a shape
+  //
+  // Given a shape on the screen, will return an SVGPoint for the directions
+  // n(north), s(south), e(east), w(west), ne(northeast), se(southeast), nw(northwest),
+  // sw(southwest).
+  //
+  //    +-+-+
+  //    |   |
+  //    +   +
+  //    |   |
+  //    +-+-+
+  //
+  // Returns an Object {n, s, e, w, nw, sw, ne, se}
+  function getScreenBBox() {
+    var targetel   = target || d3.event.target;
+
+    while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
+        targetel = targetel.parentNode;
+    }
+
+    var bbox       = {},
+        matrix     = targetel.getScreenCTM(),
+        tbbox      = targetel.getBBox(),
+        width      = tbbox.width,
+        height     = tbbox.height,
+        x          = tbbox.x,
+        y          = tbbox.y
+
+    point.x = x
+    point.y = y
+    bbox.nw = point.matrixTransform(matrix)
+    point.x += width
+    bbox.ne = point.matrixTransform(matrix)
+    point.y += height
+    bbox.se = point.matrixTransform(matrix)
+    point.x -= width
+    bbox.sw = point.matrixTransform(matrix)
+    point.y -= height / 2
+    bbox.w  = point.matrixTransform(matrix)
+    point.x += width
+    bbox.e = point.matrixTransform(matrix)
+    point.x -= width / 2
+    point.y -= height / 2
+    bbox.n = point.matrixTransform(matrix)
+    point.y += height
+    bbox.s = point.matrixTransform(matrix)
+
+    return bbox
+  }
+
+  return tip
+};

--- a/js/main.js
+++ b/js/main.js
@@ -24,9 +24,24 @@ function createVis(){
 }
 
 function sliderChanged(value) {
-  console.log("called sliderChanged: " + value)
+  // console.log("called sliderChanged: " + value)
   circlepack.wrangleData(value)
 }
+
+function onresize() {
+  // console.log("WINDOW RESIZED TO WIDTH " + window.innerWidth)
+  // console.log("WINDOW RESIZED TO WIDTH/2 " + window.innerWidth/2)
+  // tell circlepack to redraw tooltip
+  circlepack.resetTooltip();
+
+  // var totalWidth = document.getElementById(circlepack.parentElement).offsetWidth
+  // console.log("totalWidth: " + totalWidth)
+  // circlepack.width = totalWidth - circlepack.margin.left - circlepack.margin.right;
+  // circlepack.height = 450 - circlepack.margin.left - circlepack.margin.right;
+  // circlepack.svg.attr("viewBox", `0 0 ${circlepack.width} ${circlepack.height}`)
+}
+
+window.addEventListener("resize", onresize);
 
 // Start vis application
 loadData();

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 var allData = {};
 var circlepack;
+var slider;
 
 async function loadData(){
 
@@ -17,8 +18,14 @@ async function loadData(){
 }
 
 function createVis(){
-  console.log("createVis");
+  // console.log("createVis");
   circlepack = new Circlepack("circlepack", allData);
+  slider = new VisSlider("slider", allData);
+}
+
+function sliderChanged(value) {
+  console.log("called sliderChanged: " + value)
+  circlepack.wrangleData(value)
 }
 
 // Start vis application

--- a/js/main.js
+++ b/js/main.js
@@ -24,21 +24,12 @@ function createVis(){
 }
 
 function sliderChanged(value) {
-  // console.log("called sliderChanged: " + value)
   circlepack.wrangleData(value)
 }
 
 function onresize() {
-  // console.log("WINDOW RESIZED TO WIDTH " + window.innerWidth)
-  // console.log("WINDOW RESIZED TO WIDTH/2 " + window.innerWidth/2)
-  // tell circlepack to redraw tooltip
+  // tell circlepack to reset the tooltip
   circlepack.resetTooltip();
-
-  // var totalWidth = document.getElementById(circlepack.parentElement).offsetWidth
-  // console.log("totalWidth: " + totalWidth)
-  // circlepack.width = totalWidth - circlepack.margin.left - circlepack.margin.right;
-  // circlepack.height = 450 - circlepack.margin.left - circlepack.margin.right;
-  // circlepack.svg.attr("viewBox", `0 0 ${circlepack.width} ${circlepack.height}`)
 }
 
 window.addEventListener("resize", onresize);

--- a/js/visSlider.js
+++ b/js/visSlider.js
@@ -1,0 +1,51 @@
+/*
+ * Slider - Object constructor function
+ * @param _parentElement 	-- the HTML element in which to draw the plot
+ * @param _data						-- the dataset
+ */
+VisSlider = function(_parentElement, _data){
+  this.parentElement = _parentElement;
+  // this.svg = _svgElement;
+  this.data = _data;
+
+  this.initVis();
+}
+
+
+VisSlider.prototype.initVis = function() {
+  let vis = this;
+
+  vis.margin = { top: 10, right: 10, bottom: 10, left: 20 };
+
+  var tickValues = [30, 90, 180, 365]
+
+  var totalWidth = document.getElementById(vis.parentElement).offsetWidth
+  vis.width = totalWidth - vis.margin.left - vis.margin.right;
+  vis.height = 100 - vis.margin.left - vis.margin.right;
+
+  vis.svg = d3.select("#" + vis.parentElement).append("svg")
+    .attr("class", "slider-svg")
+    .attr("id", "slider-svg-id")
+    .attr("viewBox", `0 0 ${vis.width/1.5} ${vis.height}`)
+    .attr("width", "100%")
+    .attr("height", "100%")
+    .append("g")
+    .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
+
+  let slider = d3.sliderBottom()
+    .min(d3.min(tickValues))
+    .max(d3.max(tickValues))
+    .default(365)
+    .width(300)
+    .height(20)
+    .marks(tickValues)
+    .tickValues(tickValues)
+    .fill('#b0c9d0') //#d4dfe2 //rgb(199, 217, 222) //rgb(176, 201, 208)
+    .on("onchange", val => {
+      d3.event.sourceEvent.stopPropagation();
+      sliderChanged(val)
+    });
+
+  var gTime = vis.svg.call(slider)
+
+}

--- a/js/visSlider.js
+++ b/js/visSlider.js
@@ -5,12 +5,10 @@
  */
 VisSlider = function(_parentElement, _data){
   this.parentElement = _parentElement;
-  // this.svg = _svgElement;
   this.data = _data;
 
   this.initVis();
 }
-
 
 VisSlider.prototype.initVis = function() {
   let vis = this;
@@ -40,12 +38,12 @@ VisSlider.prototype.initVis = function() {
     .height(20)
     .marks(tickValues)
     .tickValues(tickValues)
-    .fill('#b0c9d0') //#d4dfe2 //rgb(199, 217, 222) //rgb(176, 201, 208)
+    .fill('#b0c9d0')
     .on("onchange", val => {
       d3.event.sourceEvent.stopPropagation();
       sliderChanged(val)
     });
 
-  var gTime = vis.svg.call(slider)
+  vis.svg.call(slider)
 
 }


### PR DESCRIPTION
### Description
Feature branch containing changes to the frontend listed in this issue:
https://github.com/IQSS/dataverse/issues/5603#issuecomment-572759009

This branch contains the following changes: 
* adds a new d3 library package 'd3-tip' which provides some convenient methods for styling tooltips
* sorts circles based on the `diff` field rather than placing them randomly
* formats tooltips differently depending on if a node is a dataset or a dataverse
* moves tooltip text logic into a helper method
* widens the svg slightly for ease of debugging
* adds "link" attribute to some of dataverses/datasets for testing purposes
* collapses nested dataset/dataverse tooltip descriptions if there are more than 5 nested
* refines "click" and "mouse" events
* [Responsiveness] On click outside the vis, hide any tooltips that are selected
* [Responsiveness] Re-size svg if window resized
* [Slider] Circle filtering hooked up to slider
* add some processing to display a tooltip to the left if the circle is close to the right edge of the window

### Screenshots
A dataverse with nested dataverses
*Note: I'm showing the diff field at the bottom of the tooltip for now, can hide this later*
![image](https://user-images.githubusercontent.com/11359963/76050477-7fc8e880-5f35-11ea-948a-b552a74cd6f4.png)

A dataverse with nested datasets
![image](https://user-images.githubusercontent.com/11359963/76050483-87888d00-5f35-11ea-8fc6-9711a6f77de2.png)

Dataset
![image](https://user-images.githubusercontent.com/11359963/76050494-90795e80-5f35-11ea-9aaa-3872a08c01c7.png)

If there are more than 5 datasets in a dataverse, show a link to “all datasets” that goes to the Dataverse page: the same link destination as the title of the Dataverse the datasets are in.

<img width="485" alt="Screen Shot 2020-03-11 at 1 23 42 AM" src="https://user-images.githubusercontent.com/11359963/76479453-30c1fe00-63e2-11ea-865f-621204b27027.png">

