### PR TITLE
Ui style clean up

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,74 +1,71 @@
-.node {
+#circlepack .node {
   cursor: pointer;
 }
-
-.node--leaf {
+#circlepack .node--leaf {
   fill: white;
 }
-
-.label {
-  font: 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
+#circlepack .label {
   text-anchor: middle;
   text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
 }
-
-.node--root {
+#circlepack .node--root {
   display: none;
 }
-
 /* VIS SIZING AND RESPONSIVENESS STYLES */
-.vis-svg {
+#circlepack .vis-svg {
   background: rgb(217, 224, 227);
 }
-
-/*    TOOLTIP STYLES    */
-.tooltip a {
-  color: unset;
-  text-decoration: unset;
-}
-
-.tooltip-title {
-  display: block;
-  margin-bottom: 5px;
-  font-size: 22px;
-  font-weight: 600;
-}
-
+/* TOOLTIP STYLES */
 .tooltip {
-  line-height: 1.5;
-  padding: 12px;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  padding: 4px 8px 7px 8px;
   opacity: 0.5;
   background-color: white;
   border-width: 2px;
   border-radius: 5px;
-  padding: 20px;
   box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -webkit-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
   -moz-box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
-  max-width: 350px; /* max tooltip width */
-  min-width: unset;
+  width: 350px;
 }
-
-.tooltip-dataverse {
-  color: rgb(194, 107, 53);
+.tooltip a {
+  color: unset;
+  text-decoration: unset;
 }
-.tooltip-dataset {
-  color: rgb(73, 134, 190);
-}
-.tooltip-date {
-  font-size: 18px;
-  color: rgb(130,130,130)
-  /*font-weight: 400;*/
-}
-.tooltip-desc {
-  display: list-item;
+.tooltip .tooltip-title {
+  display: block;
   margin-bottom: 5px;
   font-size: 18px;
-  /*font-weight: 400;*/
+  font-weight: bold;
 }
-ul {
-  padding-inline-start: 30px
+.tooltip .tooltip-details ul {
+  list-style-type: none;
+  padding: 0;
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+.tooltip .tooltip-details ul li {
+  border-bottom: 1px solid #ccc;
+}
+.tooltip .tooltip-details ul li:first-child {
+  padding-top: 5px;
+  border-top: 1px solid #ccc;
+}
+.tooltip .tooltip-details ul li:last-child {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+.tooltip .tooltip-dataverse {
+  color: rgb(194, 107, 53);
+}
+.tooltip .tooltip-dataset {
+  color: rgb(73, 134, 190);
+}
+.tooltip .tooltip-date {
+  color: rgb(130,130,130);
+}
+.tooltip .tooltip-desc {
+  display: list-item;
+  margin-bottom: 5px;
 }
 
 /* Creates a small triangle extender for the tooltip */
@@ -76,7 +73,6 @@ ul {
 .tooltip:after {
   box-sizing: border-box;
   display: inline;
-  font-size: 10px;
   width: 100%;
   line-height: 1;
   color: white;
@@ -85,16 +81,13 @@ ul {
   a westward tooltip does not interfere with circle hover */
   pointer-events: none;
 }
-
 /* Northward tooltips */
 .tooltip.n:after {
   content: "\25BC";
   margin: -4px 0 0 0;
   top: 100%;
   left: 50%;
-  /*text-align: center;*/
 }
-
 /* Adds the left arrow on the tooltip */
 .tooltip.e:after {
   content: "\25C0";
@@ -102,16 +95,13 @@ ul {
   top: 50%;
   left: -8px;
 }
-
 /* Southward tooltips */
 .tooltip.s:after {
   content: "\25B2";
   margin: 0 0 4px 0;
   top: -8px;
   left: 50%;
-
 }
-
 /* Westward tooltips */
 .tooltip.w:after {
   content: "\25B6";
@@ -119,20 +109,3 @@ ul {
   top: 50%;
   left: 100%;
 }
-/*content: "\25C0"; /* left arrow */
-/*content: "\25b6"; /* right arrow */
-/*content: "\25b2"; /* up arrow */
-/*content: "\25bc"; /* down arrow */
-
-/* OLD BASIC TOOLTIP STYLES */
-/*.tooltip {*/
-/*  position: absolute;*/
-/*  z-index: 10;*/
-/*  opacity: 0;*/
-/*  background-color: white;*/
-/*  border: solid;*/
-/*  border-width: 2px;*/
-/*  border-radius: 5px;*/
-/*  padding: 5px;*/
-/*}*/
-

--- a/index.html
+++ b/index.html
@@ -3,21 +3,11 @@
   <head>
     <title>dataverse-homepage-viz</title>
     <meta charset="utf-8" />
-<!--    <link rel="stylesheet" href="css/bootstrap.min.css">-->
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
     <div id="circlepack"></div>
     <div id="slider"></div>
-<!--        <div class="container">-->
-<!--          <div class="row">-->
-<!--            <div class="col">-->
-<!--                <p></p>-->
-<!--                <div id="circlepack"></div>-->
-<!--                <div id="slider"></div>-->
-<!--            </div>-->
-<!--          </div>-->
-<!--        </div>-->
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="https://unpkg.com/d3-simple-slider"></script>
     <script src="js/d3-tip.js"></script>

--- a/js/circlepack.js
+++ b/js/circlepack.js
@@ -39,7 +39,8 @@ Circlepack.prototype.initVis = function() {
       .attr("width", "100%")
       .attr("height", "100%")
       .append("g")
-	    // .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
+	    // .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`)
+      ;
 
    // Scales and axes
 
@@ -47,7 +48,7 @@ Circlepack.prototype.initVis = function() {
    vis.color = d3
      .scaleLinear()
      .domain([-1, 5])
-     .range(["hsl(38,76%,80%)", "hsl(38,76%,33%)"])
+     .range(["hsl(38,76%,80%)", "hsl(18,100%,27%)"])
      .interpolate(d3.interpolateHcl);
 
   // Legend
@@ -70,7 +71,7 @@ Circlepack.prototype.initVis = function() {
  /*
  *  Data wrangling
  */
-Circlepack.prototype.wrangleData = function(sliderMax = null){
+Circlepack.prototype.wrangleData = function(sliderMax = 30){
   var vis = this;
 
   // first make another copy of vis.data using spread operator
@@ -351,10 +352,10 @@ Circlepack.prototype.unHighlight = function(circle) {
 Circlepack.prototype.formatTooltip = function(d) {
   var title_html = ''
   var children_html = ''
-  var style_tag = ''
+  var obj_type = ''
 
   /*temporary for debugging:*/
-  var diff = `<div class="tooltip-diff">${d.data.diff}</div>`
+  //var diff = `<div class="tooltip-diff">${d.data.diff}</div>`
 
   // if date is present parse string as a Date and format it
   var date_label = d.data.date ? formatDate(parseDateTime(d.data.date)) : 'Date unknown'
@@ -363,31 +364,32 @@ Circlepack.prototype.formatTooltip = function(d) {
 
   // if current node you're hovering over is a dataset, construct dataset title only
   if (isDataset(d)) {
-    title_html = `<div class="tooltip-dataset tooltip-title"><a href="${title_link}" target="_blank">${d.data.name}</a></div>`
+    title_html = `<div class="tooltip-dataset tooltip-title"><span class="icon icon-dataset"/> <a href="${title_link}">${d.data.name}</a></div>`
 
   // else if it's a dataverse, construct a dataverse title and add children to the description section
   } else if (isDataverse(d)) {
-    title_html = `<div class="tooltip-dataverse tooltip-title"><a href="${title_link}" target="_blank">${d.data.name}</a></div>`
+    title_html = `<div class="tooltip-dataverse tooltip-title"><span class="icon icon-dataverse"/> <a href="${title_link}">${d.data.name}</a></div>`
     children_html = children_html.concat(`<ul>`)
 
     // if dataverse has more than 5 children show link to all datasets
     if (d.children.length > 5) {
-      style_tag = "tooltip-dataset"
-      children_html = children_html.concat(`<li class="${style_tag} tooltip-desc"><a href="${title_link}" target="_blank">All datasets</a></li>`)
+      obj_type = "dataset"
+      children_html = children_html.concat(`<li class="tooltip-${obj_type} tooltip-desc"><a href="${title_link}">ALL DATASETS <span class="glyphicon glyphicon-chevron-right"></span></a></li>`)
 
     } else {
       // else show all children
       d.children.forEach(child => {
         if (isDataset(child)) {
-          style_tag = "tooltip-dataset"
+          obj_type = "dataset"
         } else if (isDataverse(child)) {
-          style_tag = "tooltip-dataverse"
+          obj_type = "dataverse"
         }
-        children_html = children_html.concat(`<li class="${style_tag} tooltip-desc"><a href="${child.data.link}" target="_blank">${child.data.name}</a></li>`)
+        children_html = children_html.concat(`<li class="tooltip-${obj_type} tooltip-desc"><span class="icon icon-${obj_type}"/> <a href="${child.data.link}">${child.data.name}</a></li>`)
       })
     }
     children_html = children_html.concat(`</ul>`)
   }
-  return '<div class="tooltip-details">' + title_html + date_html + children_html + diff + '</div">'
+  return '<div class="tooltip-details">' + title_html + date_html + children_html + '</div">'
+  // + diff
 }
 

--- a/js/visSlider.js
+++ b/js/visSlider.js
@@ -13,29 +13,29 @@ VisSlider = function(_parentElement, _data){
 VisSlider.prototype.initVis = function() {
   let vis = this;
 
-  vis.margin = { top: 10, right: 10, bottom: 10, left: 20 };
-
   var tickValues = [30, 90, 180, 365]
 
   var totalWidth = document.getElementById(vis.parentElement).offsetWidth
-  vis.width = totalWidth - vis.margin.left - vis.margin.right;
-  vis.height = 100 - vis.margin.left - vis.margin.right;
+  vis.width = totalWidth;
+  vis.height = 42;
 
-  vis.svg = d3.select("#" + vis.parentElement).append("svg")
+  vis.svg = d3.select("#" + vis.parentElement).append("text")
+    .text("Jan 01, 2018 - Dec 31, 2018")
+    .attr("style", "margin-left:5px;")
+    .append("svg")
     .attr("class", "slider-svg")
     .attr("id", "slider-svg-id")
-    .attr("viewBox", `0 0 ${vis.width/1.5} ${vis.height}`)
+    .attr("viewBox", `0 0 ${vis.width} ${vis.height}`)
     .attr("width", "100%")
     .attr("height", "100%")
     .append("g")
-    .attr("transform", `translate(${vis.margin.left}, ${vis.margin.top})`);
+    .attr("transform", `translate(15,10)`);
 
   let slider = d3.sliderBottom()
     .min(d3.min(tickValues))
     .max(d3.max(tickValues))
-    .default(365)
-    .width(300)
-    .height(20)
+    .default(30)
+    .width(329)
     .marks(tickValues)
     .tickValues(tickValues)
     .fill('#b0c9d0')
@@ -45,5 +45,7 @@ VisSlider.prototype.initVis = function() {
     });
 
   vis.svg.call(slider)
-
+    .selectAll(".axis .tick text, .slider .parameter-value text")
+    .attr("font-size", 12)
+    .attr("dy", 0)
 }


### PR DESCRIPTION
Styled and cleaned up the tooltips, updated circle colors. Changes include use of Bootstrap glyphicons that will only work when linked to the Bootstrap CSS and resource files, which is the case when the visualization code is added the Dataverse custom homepage (see attachment).

<img width="1159" alt="Screen Shot 2020-05-15 at 10 21 53 AM" src="https://user-images.githubusercontent.com/687227/82061085-3d8af880-9696-11ea-8b3e-f5aaa2099152.png">
